### PR TITLE
Add compatibility for Magento MFTF 2.5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "",
     "require": {
         "php": "~7.1.0|~7.2.0",
-        "magento/magento2-functional-testing-framework": "~2.3.0|~2.4.0",
+        "magento/magento2-functional-testing-framework": "~2.3.0|~2.4.0|^2.5.0",
         "magento/magento-composer-installer": "*"
     },
     "type": "magento2-module",


### PR DESCRIPTION
As an answer to Request #4, I'm adding compatibility to MFTF `2.5.*`.
After verification, I'm sure that we don't need to change anything.